### PR TITLE
ADT constructor protection from tag override

### DIFF
--- a/packages/morphic/src/Adt/ctors/index.ts
+++ b/packages/morphic/src/Adt/ctors/index.ts
@@ -29,8 +29,8 @@ export const Ctors =
   <A extends Tagged<Tag>, Tag extends string>(tag: Tag) =>
   (keys: KeysDefinition<A, Tag>): Ctors<A, Tag> => {
     const ctors = mapWithIndex((key, _) => (props: object) => ({
-      [tag]: key,
-      ...props
+      ...props,
+      [tag]: key
     }))(keys)
     return {
       of: ctors as Of<A, Tag>,

--- a/packages/morphic/test/adt.test.ts
+++ b/packages/morphic/test/adt.test.ts
@@ -88,4 +88,10 @@ describe("Adt", () => {
       'Tagged(_tag)({"_tag":"Bar","bar":"string"} | {"_tag":"Foo","foo":"string"})'
     )
   })
+
+  it("ctor is protected from tag override", () => {
+    const foo = FooBar.of.Foo({ foo: "" })
+    const bar = FooBar.of.Bar({ ...foo, bar: "" })
+    expect(bar._tag).toBe("Bar")
+  })
 })


### PR DESCRIPTION
BTW, this had already been fixed on `morphic-ts`:
- https://github.com/sledorze/morphic-ts/blob/master/packages/morphic-adt/src/ctors.ts#L42
- https://github.com/sledorze/morphic-ts/pull/134/files#diff-6aa3c061f147cdc0e8dee7d311be481a89024378a762b74e0d4e5490432ae427